### PR TITLE
move licensing to gmkit

### DIFF
--- a/licensing/license.go
+++ b/licensing/license.go
@@ -1,0 +1,68 @@
+package licensing
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/hyperboloide/lk"
+	"github.com/pkg/errors"
+)
+
+// ErrLicenseInvalidSignature is the error returned when the license has an invalid signature
+var ErrLicenseInvalidSignature = errors.New("license contains invalid signature")
+
+// License is the minimum requirements a struct has to expose for being able to be a product license
+type License interface {
+	ExpiresAt() time.Time
+}
+
+// IsExpired returns true if the license is expired
+func IsExpired(l License) bool {
+	return time.Now().After(l.ExpiresAt())
+}
+
+// Sign signs a license and returns the base32 encoded license key
+func Sign(privateKey string, l License) (string, error) {
+	b, err := json.Marshal(l)
+	if err != nil {
+		return "", errors.Wrap(err, "marshaling json")
+	}
+
+	key, err := lk.PrivateKeyFromB32String(privateKey)
+	if err != nil {
+		return "", errors.Wrap(err, "unmarshaling key")
+	}
+
+	lic, err := lk.NewLicense(key, b)
+	if err != nil {
+		return "", errors.Wrap(err, "generating license")
+	}
+
+	licenseB32, err := lic.ToB32String()
+	return licenseB32, errors.Wrap(err, "transforming license to base32 string")
+}
+
+// LicenseFromKey takes a licenseKey and a public key and rehydrates it into a
+// the destination License
+func LicenseFromKey(licenseKey, publicKey string, dest License) error {
+	key, err := lk.PublicKeyFromB32String(publicKey)
+	if err != nil {
+		return errors.Wrap(err, "unpacking base32 public key")
+	}
+
+	license, err := lk.LicenseFromB32String(licenseKey)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling license from b32 string")
+	}
+
+	if ok, err := license.Verify(key); err != nil {
+		return errors.Wrap(err, "verifying license")
+	} else if !ok {
+		return ErrLicenseInvalidSignature
+	}
+
+	if err := json.Unmarshal(license.Data, &dest); err != nil {
+		return errors.Wrap(err, "unmarshaling license payload json")
+	}
+	return nil
+}

--- a/licensing/license_test.go
+++ b/licensing/license_test.go
@@ -1,0 +1,58 @@
+package licensing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testLicenseKeyPublic  = `AQ64EJBD52VNWG54W3PFXORDPRM4UTYV2IFQ6M6YSA3XBHUDMLSN4Y52OR5GCCYXEX5I6HMYJXGFVRVTQQTW55XSFP2GCTWXM4WGKUXHG7ROJ4RU3JXZA745R3YP4FWDSZPXCMBA65VVEUCYAHHJ7B2SOLAA====`
+	testLicenseKeyPrivate = `FD7YCAYBAEFXA22DN5XHIYLJNZSXEAP7QIAACAQBANIHKYQBBIAACAKEAH7YIAAAAAFP7AYFAEBP7BQAAAAP7GP7QIAWCBB5YISCH3VK3MN3ZNW6LO5CG7CZZJHRLUQLB4Z5REBXOCPIGYXE3ZR3U5D2MEFROJP2R4OZQTOMLLDLHBBHN33PEK7UMFHNOZZMMVJOON7C4TZDJWTPSB7Z3DXQ7YLMHFS7OEYCB53LKJIFQAOOT6DVE4WAAEYQFSYTGL6DNL47YFJMZEB2KFSJET4G4GPKFLGAYIGB4XHGZZMPB7A3YLPIJV2Y6Q77N3H2T7YJY4NC2AAA====`
+
+	testLicenseKeyPrivate2 = `FD7YCAYBAEFXA22DN5XHIYLJNZSXEAP7QIAACAQBANIHKYQBBIAACAKEAH7YIAAAAAFP7AYFAEBP7BQAAAAP7GP7QIAWCBFQAV5R437XABDVFPNAXYER3YADLG3P6GA3KHUDYRVBLUE6ZYO6FIR5BDEDWHLVJ3WKBKT4Q2HMUB372Q6ICA4FQZ72Z3OCIGJSUAWXBP75XRAYP7OXFQQEPXSTPKCSLZLBMPCPXN6WMG2K25NDGRVHUVZDAEYQEITDLAUZJXC6JIAFUZJAMGNEE4FXHXHP2LVQBOOBOLPGGAXNCTQI4M43Y4MLWLWLLKKOX2DRMB3KBYAA====`
+)
+
+//var logs = flag.Bool("logs", false, "whether or not to enable logs during testing")
+
+func TestLicense(t *testing.T) {
+	lic := LicenseMF2{
+		Expiration:            time.Now().Add(1 * time.Hour),
+		BaseURL:               "https://foo.example.com/",
+		EnforceBaseURLCheck:   true,
+		LicenseGeneratedAt:    time.Now(),
+		LicenseGenerationHost: "somehost.example.com",
+	}
+
+	var licenseKey string
+	t.Run("normal", func(t *testing.T) {
+		var err error
+		licenseKey, err = Sign(testLicenseKeyPrivate, lic)
+		require.NoError(t, err)
+
+		var fromLicense LicenseMF2
+		require.NoError(t, LicenseFromKey(licenseKey, testLicenseKeyPublic, &fromLicense))
+
+		require.True(t, fromLicense.Expiration.Equal(lic.Expiration))
+		require.Equal(t, fromLicense.BaseURL, lic.BaseURL)
+		require.Equal(t, fromLicense.EnforceBaseURLCheck, lic.EnforceBaseURLCheck)
+		require.True(t, fromLicense.LicenseGeneratedAt.Equal(lic.LicenseGeneratedAt))
+		require.Equal(t, fromLicense.LicenseGenerationHost, lic.LicenseGenerationHost)
+	})
+
+	t.Run("invalid license key", func(t *testing.T) {
+		var dest LicenseMF2
+		require.Error(t, LicenseFromKey("abcdefg", testLicenseKeyPublic, &dest))
+	})
+
+	t.Run("valid license key, signed by wrong key", func(t *testing.T) {
+		licenseKey, err := Sign(testLicenseKeyPrivate2, lic)
+		require.NoError(t, err)
+
+		var dest LicenseMF2
+		err = LicenseFromKey(licenseKey, testLicenseKeyPublic, &dest)
+		require.Error(t, err)
+		require.Equal(t, err, ErrLicenseInvalidSignature)
+	})
+}

--- a/licensing/mf2.go
+++ b/licensing/mf2.go
@@ -1,0 +1,27 @@
+package licensing
+
+import "time"
+
+// LicenseMF2 is a GraymMeta/Curio Platform License
+type LicenseMF2 struct {
+	// Expiration is the timestamp at which the license expires
+	Expiration time.Time `json:"expiration"`
+	// BaseURL is the platform's base URL. We include this in the signed license to
+	// prevent customers from spinning up multiple instances of the platform behind
+	// a load balancer
+	BaseURL string `json:"base_url"`
+	// EnforceBaseURLCheck dictates whether or not we should enforce the BaseURL
+	// check. This is necessary because we want to use a single license across all
+	// sites hosted by GrayMeta (in which case this would be false). For our typical
+	// Enterprise Terraform based customers, this will be true
+	EnforceBaseURLCheck bool `json:"enforce_base_url_check"`
+	// LicenseGeneratedAt is the timestamp when the license was generated
+	LicenseGeneratedAt time.Time `json:"license_generated_at"`
+	// LicenseGenerationHost is the hostname of the server where the license was generated
+	LicenseGenerationHost string `json:"license_generation_host"`
+}
+
+// ExpiresAt returns the license expiration time
+func (l LicenseMF2) ExpiresAt() time.Time {
+	return l.Expiration
+}


### PR DESCRIPTION
This pulls the mf2 license struct into gmkit (so we can access it from other places) and also decouples the signing logic from the struct so that we could reuse the licensing code for other products if needed (they just have to define their own structs).

Will make the appropriate changes to mf2 once this is merged in.