### PR TITLE
GP-1769: moving the backoffer over to gmkit

### DIFF
--- a/backoff/runners.go
+++ b/backoff/runners.go
@@ -1,0 +1,232 @@
+package backoff
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/graymeta/gmkit/errors"
+	"github.com/graymeta/gmkit/logger"
+)
+
+var (
+	defaultInitialBackoff = 1 * time.Second
+	defaultMaxBackoff     = 1 * time.Minute
+	defaultMaxCalls       = 10
+)
+
+// Backoffer is an interface to abstract the Runner type into
+// just a the backoff call.
+type Backoffer interface {
+	Backoff(fn func() error) error
+	BackoffCtx(ctx context.Context, fn func(context.Context) error) error
+}
+
+// Runner is a backoff runner that will run a backoff func, safe for concurrent use,
+// and provides DI for a backoff callsites.
+type Runner struct {
+	initDur, maxDur time.Duration
+	maxCalls        int
+	jitter          bool
+	logger          *logger.L
+}
+
+// New returns a runner with the defined options. If no options are given,
+// then the new runner is given the defaults for initial and max backoff as well
+// as max calls. The defaults being:
+//		InitBackoff: 1 second
+//		MaxBackoff:	 1 minute
+//		MaxCalls:	 10
+//		Jitter: 	 false
+func New(opts ...RunnerOptFn) Runner {
+	r := Runner{
+		initDur:  defaultInitialBackoff,
+		maxDur:   defaultMaxBackoff,
+		maxCalls: defaultMaxCalls,
+	}
+
+	for _, o := range opts {
+		r = o(r)
+	}
+
+	return r
+}
+
+// RunnerOptFn is a functional option to set the
+type RunnerOptFn func(r Runner) Runner
+
+// InitBackoff sets the runners initial backoff time.
+func InitBackoff(i time.Duration) RunnerOptFn {
+	return func(r Runner) Runner {
+		if i < 0 {
+			return r
+		}
+		r.initDur = i
+		return r
+	}
+}
+
+// MaxBackoff sets the runners max backoff time.
+func MaxBackoff(m time.Duration) RunnerOptFn {
+	return func(r Runner) Runner {
+		if m < 0 {
+			return r
+		}
+		r.maxDur = m
+		return r
+	}
+}
+
+// MaxCalls sets the runners max call count.
+func MaxCalls(m int) RunnerOptFn {
+	return func(r Runner) Runner {
+		if m < 0 {
+			return r
+		}
+		r.maxCalls = m
+		return r
+	}
+}
+
+// Jitter sets the Backoff method to jitter the backoff duration.
+func Jitter() RunnerOptFn {
+	return func(r Runner) Runner {
+		r.jitter = true
+		return r
+	}
+}
+
+// Logger sets the Logger on the Runner type.
+func Logger(l *logger.L) RunnerOptFn {
+	return func(r Runner) Runner {
+		r.logger = l
+		return r
+	}
+}
+
+// New allows one to create a new runner, with any options, from an existing
+// runner type.
+func (r Runner) New(opts ...RunnerOptFn) Runner {
+	newRunner := r
+	for _, o := range opts {
+		newRunner = o(newRunner)
+	}
+	return newRunner
+}
+
+// Backoff runs the given func in a backoff loop defined by the runner type.
+func (r Runner) Backoff(fn func() error) error {
+	rander := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	backoff := time.Duration(0)
+	calls := 0
+	for {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if retrier, ok := err.(errors.Retrier); ok && !retrier.Retry() {
+			return err
+		}
+
+		calls++
+		if r.maxCalls != 0 && calls >= r.maxCalls {
+			return err
+		}
+		if backoff == 0 {
+			backoff = r.initDur
+		} else {
+			backoff *= 2
+		}
+		if r.maxDur != 0 && backoff >= r.maxDur {
+			backoff = r.maxDur
+		}
+
+		sleep := backoff
+		if r.jitter {
+			sleep = time.Duration(rander.Int63n(int64(backoff)))
+		}
+
+		time.Sleep(sleep)
+
+		if r.logger != nil {
+			errMsg := err.Error()
+			if clientErr, ok := err.(*errors.ClientErr); ok {
+				errMsg = clientErr.BackoffMessage()
+			}
+
+			r.logger.Warn("backoff", "calls", calls, "retry_after", backoff, "error", errMsg)
+		}
+	}
+}
+
+// BackoffCtx runs the given func in a backoff loop defined by the runner type.
+func (r Runner) BackoffCtx(ctx context.Context, fn func(context.Context) error) error {
+	rander := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	backoff := time.Duration(0)
+	calls := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+		if retrier, ok := err.(errors.Retrier); ok && !retrier.Retry() {
+			return err
+		}
+
+		calls++
+		if r.maxCalls != 0 && calls >= r.maxCalls {
+			return err
+		}
+		if backoff == 0 {
+			backoff = r.initDur
+		} else {
+			backoff *= 2
+		}
+		if r.maxDur != 0 && backoff > r.maxDur {
+			backoff = r.maxDur
+		}
+
+		sleep := backoff
+		if r.jitter {
+			sleep = time.Duration(rander.Int63n(int64(backoff)))
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sleep):
+		}
+
+		if r.logger != nil {
+			errMsg := err.Error()
+			if clientErr, ok := err.(*errors.ClientErr); ok {
+				errMsg = clientErr.BackoffMessage()
+			}
+
+			r.logger.Warn("backoff", "calls", calls, "retry_after", backoff, "error", errMsg)
+		}
+	}
+}
+
+// NoopBackoff is a backoff that is a noop for the backoff. Only calls the func provided to the backoff calls.
+type NoopBackoff struct{}
+
+var _ Backoffer = NoopBackoff{}
+
+// Backoff is a backoff runner.
+func (n NoopBackoff) Backoff(fn func() error) error {
+	return fn()
+}
+
+// BackoffCtx is a backoff runner that may be interrupted via the provided context.
+func (n NoopBackoff) BackoffCtx(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}

--- a/errors/client.go
+++ b/errors/client.go
@@ -1,0 +1,190 @@
+package errors
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/graymeta/gmkit/http/middleware"
+)
+
+// ClientErr is an error type that provides useful error messages that include
+// both request and response bodies, status code of response and valid request
+// parameters.
+type ClientErr struct {
+	op         string
+	u          url.URL
+	method     string
+	errMsg     string
+	respBody   string
+	reqBody    string
+	reqID      string
+	meta       []string
+	StatusCode int
+	retry      bool
+	notFound   bool
+	exists     bool
+}
+
+// NewClientErr is a constructor for a client error. The provided options
+// allow the caller to set an optional retry.
+func NewClientErr(op string, err error, resp *http.Response, opts ...ClientOptFn) error {
+	newClientErr := &ClientErr{
+		op:     op,
+		errMsg: "received unexpected response",
+	}
+	for _, o := range opts {
+		newClientErr = o(newClientErr)
+	}
+
+	if err != nil {
+		newClientErr.errMsg = err.Error()
+	}
+
+	if resp == nil {
+		return newClientErr
+	}
+
+	if req := resp.Request; req != nil {
+		newClientErr.u = *req.URL
+		newClientErr.method = req.Method
+
+		if req.Header != nil && strings.Contains(req.Header.Get("Content-Type"), "application/json") {
+			if body, err := ioutil.ReadAll(req.Body); err == nil {
+				newClientErr.respBody = string(body)
+			}
+		}
+	}
+	newClientErr.StatusCode = resp.StatusCode
+	newClientErr.reqID = resp.Header.Get(middleware.RequestHeader)
+
+	if body, err := ioutil.ReadAll(resp.Body); err == nil {
+		newClientErr.respBody = string(body)
+	}
+
+	return newClientErr
+}
+
+// Error returns the full client error message.
+func (e *ClientErr) Error() string {
+	parts := []string{e.errorBase()}
+
+	if respBody := e.respBody; respBody != "" {
+		parts = append(parts, fmt.Sprintf("response_body=%q", respBody))
+	}
+
+	if reqBody := e.reqBody; reqBody != "" {
+		parts = append(parts, fmt.Sprintf("request_body=%q", reqBody))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// BackoffMessage provides a condensed error message that can be consumed during
+// a backoff loop.
+func (e *ClientErr) BackoffMessage() string {
+	return e.errorBase()
+}
+
+// Retry provides the retry behavior.
+func (e *ClientErr) Retry() bool {
+	return e.retry
+}
+
+// NotFound provides the NotFounder behavior.
+func (e *ClientErr) NotFound() bool {
+	return e.notFound
+}
+
+// Exists provides the Exister behavior.
+func (e *ClientErr) Exists() bool {
+	return e.exists
+}
+
+func (e *ClientErr) errorBase() string {
+	var parts []string
+
+	if e.StatusCode > 0 {
+		parts = append(parts, fmt.Sprintf("status=%d", e.StatusCode))
+	}
+
+	if e.method != "" {
+		parts = append(parts, fmt.Sprintf("method=%s", e.method))
+	}
+
+	if e.reqID != "" {
+		parts = append(parts, fmt.Sprintf("response_http_req_id=%q", e.reqID))
+	}
+
+	if len(e.meta) > 0 {
+		parts = append(parts, getPairPrint(e.meta))
+	}
+
+	parts = append(parts, fmt.Sprintf("err=%q", e.errMsg))
+
+	if e.u.String() != "" {
+		q := e.u.Query()
+		if q.Get("access_token") != "" {
+			q.Set("access_token", "REDACTED")
+		}
+		if q.Get("secret") != "" {
+			q.Set("secret", "REDACTED")
+		}
+		e.u.RawQuery = q.Encode()
+		parts = append(parts, fmt.Sprintf("url=%q", e.u.String()))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// ClientOptFn is a optional parameter that allows one to extend
+// a client error.
+type ClientOptFn func(o *ClientErr) *ClientErr
+
+// Exists sets the client error to Exists, exists=true.
+func Exists() ClientOptFn {
+	return func(o *ClientErr) *ClientErr {
+		o.exists = true
+		return o
+	}
+}
+
+// Meta sets key value pairs to add context to the error output.
+func Meta(key, value string, pairs ...string) ClientOptFn {
+	return func(e *ClientErr) *ClientErr {
+		e.meta = append(e.meta, key, value)
+		e.meta = append(e.meta, pairs...)
+		return e
+	}
+}
+
+// NotFound sets the client error to NotFound, notFound=true.
+func NotFound() ClientOptFn {
+	return func(o *ClientErr) *ClientErr {
+		o.notFound = true
+		return o
+	}
+}
+
+// Retry sets the option and subsequent client error to retriable, retry=true.
+func Retry() ClientOptFn {
+	return func(o *ClientErr) *ClientErr {
+		o.retry = true
+		return o
+	}
+}
+
+func getPairPrint(pairs []string) string {
+	var paired []string
+	for index := 0; index < len(pairs)/2; index++ {
+		i := index * 2
+		pair := pairs[i : i+2]
+		if len(pair) != 2 {
+			break
+		}
+		paired = append(paired, fmt.Sprintf("%s=%q", pair[0], pair[1]))
+	}
+	return strings.Join(paired, " ")
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,42 @@
+package errors
+
+// NotFounder determines if an error exhibits the behavior of a resource not found err.
+type NotFounder interface {
+	NotFound() bool
+}
+
+// Exister determines if an error exhibits the behavior of a resource already exists err.
+type Exister interface {
+	Exists() bool
+}
+
+// Temporarier determines if an error exhibits the behavior of a system with services that are
+// unreachable for whatever reason and are temporarily unavailable.
+type Temporarier interface {
+	Temporary() bool
+}
+
+// Conflicter determines if an error exhibits the behavior of a conflict err. This corresponds
+// to times when you receive unexpected errors or an error of high severity.
+type Conflicter interface {
+	Conflict() bool
+}
+
+// Retrier determines if an error exhibits the behavior of an error that is safe to retry.
+// TODO: a lot of times these types of errors may respond with a time/duration for when a retry
+// is safe to commence. May be worth considering.
+type Retrier interface {
+	Retry() bool
+}
+
+// HTTP determines if an error exhibits the behavior of an error that provides an HTTP status code and
+// the error message itself is safe for returning to a client.
+type HTTP interface {
+	StatusCode() int
+}
+
+// InternalErrorMessage provides a message separate from that returned by a call
+// to Error() that is for internal (non-client) consumption.
+type InternalErrorMessage interface {
+	InternalErrorMessage() string
+}

--- a/http/header_range.go
+++ b/http/header_range.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	errMissingBytesPrefix = errors.New("missing bytes= prefix")
+	errInvalidNumPieces   = errors.New("invalid num pieces")
+)
+
+// ParseHeaderRange parses the Range http header. Only supports the expresion of
+// a single range. Returns the start and end values of the range.
+// Example: "bytes=1234-4567" would return 1234 and 4567
+func ParseHeaderRange(h string) (int64, int64, error) {
+	if !strings.HasPrefix(h, "bytes=") {
+		return 0, 0, errMissingBytesPrefix
+	}
+
+	h = strings.TrimPrefix(h, "bytes=")
+
+	pieces := strings.Split(h, "-")
+	if len(pieces) != 2 {
+		return 0, 0, errInvalidNumPieces
+	}
+
+	start, err := strconv.ParseInt(pieces[0], 10, 64)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "parsing start value")
+	}
+
+	end, err := strconv.ParseInt(pieces[1], 10, 64)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "parsing end value")
+	}
+
+	return start, end, nil
+}
+
+// FormatHeaderRange generates the Range header string given start and end values
+func FormatHeaderRange(start, end int64) string {
+	return fmt.Sprintf("bytes=%d-%d", start, end)
+}

--- a/http/header_range_test.go
+++ b/http/header_range_test.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHeaderRange(t *testing.T) {
+	var tests = []struct {
+		desc  string
+		input string
+		start int64
+		end   int64
+		err   string
+	}{
+		{"normal", "bytes=1234-4567", 1234, 4567, ""},
+		{"no prefix", "1234-4567", 0, 0, errMissingBytesPrefix.Error()},
+		{"invalid pieces", "bytes=1234-4567-7890", 0, 0, errInvalidNumPieces.Error()},
+		{"invalid pieces", "bytes=1234-4567-7890", 0, 0, errInvalidNumPieces.Error()},
+		{"invalid start", "bytes=foo-4567", 0, 0, "parsing start value"},
+		{"invalid end", "bytes=1234-foo", 0, 0, "parsing end value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			start, end, err := ParseHeaderRange(tt.input)
+
+			require.Equal(t, tt.start, start)
+			require.Equal(t, tt.end, end)
+			if tt.err == "" {
+				return
+			}
+
+			require.True(t, strings.Contains(err.Error(), tt.err))
+		})
+	}
+}
+
+func TestFormatHeaderRange(t *testing.T) {
+	require.Equal(t, "bytes=1234-4567", FormatHeaderRange(1234, 4567))
+}

--- a/http/middleware/frames.go
+++ b/http/middleware/frames.go
@@ -1,0 +1,20 @@
+package middleware
+
+import "net/http"
+
+// constants for the X-Frame-Options header
+const (
+	XFrameOptionsSameOrigin = "sameorigin"
+	XFrameOptionsDeny       = "deny"
+)
+
+// FrameOptions is middleware that sets the X-Frame-Options header. Policy should
+// be one of deny|sameorigin|allow-from https://example.com/
+func FrameOptions(policy string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Frame-Options", policy)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/http/middleware/frames_test.go
+++ b/http/middleware/frames_test.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrameOptions(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(body)
+	})
+	srv := httptest.NewServer(FrameOptions("foobar")(handler))
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, "foobar", resp.Header.Get("X-Frame-Options"))
+}

--- a/http/middleware/gzip.go
+++ b/http/middleware/gzip.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type gzipWriter struct {
+	http.ResponseWriter
+	w io.Writer
+}
+
+func (gzw gzipWriter) Write(b []byte) (int, error) {
+	return gzw.w.Write(b)
+}
+
+func (gzw gzipWriter) WriterHeader(statusCode int) {
+	// gzw.w.Close() (gzip writer) will write a footer even if no data has been written.
+	// StatusNotModified and StatusNoContent expect an empty body so swap for generic ResponseWriter instead
+	if statusCode == http.StatusNoContent || statusCode == http.StatusNotModified {
+		gzw.w = gzw.ResponseWriter
+	}
+	gzw.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Compress is middleware that implements gzip compression
+func Compress(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			h.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		gzw := gzipWriter{w: gz, ResponseWriter: w}
+		h.ServeHTTP(gzw, r)
+	})
+}

--- a/http/middleware/gzip_test.go
+++ b/http/middleware/gzip_test.go
@@ -1,0 +1,1069 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoGzip(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(body)
+	})
+	srv := httptest.NewServer(Compress(handler))
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	b, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, b)
+}
+
+func TestGzip(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(body)
+	})
+	srv := httptest.NewServer(Compress(handler))
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	req.Header.Add("Accept-Encoding", "gzip, deflate")
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	h := res.Header.Get("Content-Encoding")
+	require.Contains(t, h, "gzip")
+	b, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	gr, err := gzip.NewReader(bytes.NewReader(b))
+	require.NoError(t, err)
+	uncompressed, err := ioutil.ReadAll(gr)
+	require.NoError(t, err)
+	require.Equal(t, body, uncompressed)
+	require.Less(t, len(b), len(body))
+}
+
+func TestNoContent(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(Compress(handler))
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	req.Header.Add("Accept-Encoding", "gzip, deflate")
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	h := res.Header.Get("Content-Encoding")
+	require.Contains(t, h, "gzip")
+	b, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Len(t, b, 0)
+}
+
+var body = []byte(`{
+	"query": "png",
+	"limit": 10,
+	"page": 0,
+	"types": null,
+	"fields": null,
+	"only": null,
+	"filters": {
+		"terms": [],
+		"multi_terms": [],
+		"ranges": [],
+		"exists": null
+	},
+	"sort_fields": [],
+	"disable_aggr": false,
+	"total_hits": 5,
+	"results": [
+		{
+			"result": {
+				"_id": "a9f58620222da083d7c9fa1128103b50",
+				"file_size": 517310,
+				"last_modified": "2017-03-01T15:13:03Z",
+				"location_id": "AVqtzIBxSHvY6IzeCzPZ",
+				"location_kind": "local",
+				"location_name": "duplicatesss",
+				"mime_type": "image/png",
+				"name": "Pasted image at 2017_03_01 07_11 AM.png",
+				"stow_container_id": "/data/small",
+				"stow_container_name": "small",
+				"stow_url": "file:///data/small/Pasted%20image%20at%202017_03_01%2007_11%20AM.png",
+				"thumbnail": {
+					"frames": {
+						"count": 0
+					},
+					"height": 270,
+					"path": "thumbnailer/thumb.jpg",
+					"type": "image",
+					"width": 270
+				}
+			},
+			"highlight": [
+				{
+					"field": "m2ts.format.filename",
+					"fragments": [
+						"\u0026#x2F;tmp\u0026#x2F;harvester416358298\u0026#x2F;a9f58620222da083d7c9fa1128103b50.\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "m2ts.format.format_long_name",
+					"fragments": [
+						"piped \u003cem\u003epng\u003c/em\u003e sequence"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_long_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e (Portable Network Graphics) image"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_name",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codecs_image",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.complete_name",
+					"fragments": [
+						"\u0026#x2F;tmp\u0026#x2F;harvester416358298\u0026#x2F;a9f58620222da083d7c9fa1128103b50.\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.file_extension",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_with_hint_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mime_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "stow_url",
+					"fragments": [
+						"file:\u0026#x2F;\u0026#x2F;\u0026#x2F;data\u0026#x2F;small\u0026#x2F;Pasted%20image%20at%202017_03_01%2007_11%20AM.\u003cem\u003epng\u003c/em\u003e"
+					]
+				}
+			],
+			"score": 0.9581877
+		},
+		{
+			"result": {
+				"_id": "b4532a5af54b7ac41f5148ef68144c71",
+				"file_size": 517310,
+				"last_modified": "2017-03-01T15:13:03Z",
+				"location_id": "AVqtzIBxSHvY6IzeCzPZ",
+				"location_kind": "local",
+				"location_name": "duplicatesss",
+				"mime_type": "image/png",
+				"name": "Pasted image at 2017_03_01 07_11 AM.png",
+				"stow_container_id": "/data/small",
+				"stow_container_name": "small",
+				"stow_url": "file:///data/small/dup/Pasted%20image%20at%202017_03_01%2007_11%20AM.png",
+				"thumbnail": {
+					"frames": {
+						"count": 0
+					},
+					"height": 270,
+					"path": "thumbnailer/thumb.jpg",
+					"type": "image",
+					"width": 270
+				}
+			},
+			"highlight": [
+				{
+					"field": "m2ts.format.filename",
+					"fragments": [
+						"\u0026#x2F;tmp\u0026#x2F;harvester948444567\u0026#x2F;b4532a5af54b7ac41f5148ef68144c71.\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "m2ts.format.format_long_name",
+					"fragments": [
+						"piped \u003cem\u003epng\u003c/em\u003e sequence"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_long_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e (Portable Network Graphics) image"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_name",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codecs_image",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.complete_name",
+					"fragments": [
+						"\u0026#x2F;tmp\u0026#x2F;harvester948444567\u0026#x2F;b4532a5af54b7ac41f5148ef68144c71.\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.file_extension",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_with_hint_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mime_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "stow_url",
+					"fragments": [
+						"file:\u0026#x2F;\u0026#x2F;\u0026#x2F;data\u0026#x2F;small\u0026#x2F;dup\u0026#x2F;Pasted%20image%20at%202017_03_01%2007_11%20AM.\u003cem\u003epng\u003c/em\u003e"
+					]
+				}
+			],
+			"score": 0.89747846
+		},
+		{
+			"result": {
+				"_id": "8e68b38e72968ae42595e251371d7b55",
+				"file_size": 517310,
+				"last_modified": "2017-03-01T15:13:03Z",
+				"location_id": "AVqtzIBxSHvY6IzeCzPZ",
+				"location_kind": "local",
+				"location_name": "duplicatesss",
+				"mime_type": "image/png",
+				"name": "Pasted image at 2017_03_01 07_11 AM.png",
+				"stow_container_id": "/data/small",
+				"stow_container_name": "small",
+				"stow_url": "file:///data/small/dup-kopia%202/Pasted%20image%20at%202017_03_01%2007_11%20AM.png",
+				"thumbnail": {
+					"frames": {
+						"count": 0
+					},
+					"height": 270,
+					"path": "thumbnailer/thumb.jpg",
+					"type": "image",
+					"width": 270
+				}
+			},
+			"highlight": [
+				{
+					"field": "m2ts.format.filename",
+					"fragments": [
+						"\u0026#x2F;tmp\u0026#x2F;harvester595744709\u0026#x2F;8e68b38e72968ae42595e251371d7b55.\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "m2ts.format.format_long_name",
+					"fragments": [
+						"piped \u003cem\u003epng\u003c/em\u003e sequence"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_long_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e (Portable Network Graphics) image"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_name",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codecs_image",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.complete_name",
+					"fragments": [
+						"\u0026#x2F;tmp\u0026#x2F;harvester595744709\u0026#x2F;8e68b38e72968ae42595e251371d7b55.\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.file_extension",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_with_hint_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mime_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "stow_url",
+					"fragments": [
+						"file:\u0026#x2F;\u0026#x2F;\u0026#x2F;data\u0026#x2F;small\u0026#x2F;dup-kopia%202\u0026#x2F;Pasted%20image%20at%202017_03_01%2007_11%20AM.\u003cem\u003epng\u003c/em\u003e"
+					]
+				}
+			],
+			"score": 0.89747846
+		},
+		{
+			"result": {
+				"_id": "ab210168127f3ac1ef68394106fdf093",
+				"file_size": 517310,
+				"last_modified": "2017-03-01T15:13:03Z",
+				"location_id": "AVqtzIBxSHvY6IzeCzPZ",
+				"location_kind": "local",
+				"location_name": "duplicatesss",
+				"mime_type": "image/png",
+				"name": "Pasted image at 2017_03_01 07_11 AM.png",
+				"stow_container_id": "/data/small",
+				"stow_container_name": "small",
+				"stow_url": "file:///data/small/dup-kopia%203/Pasted%20image%20at%202017_03_01%2007_11%20AM.png",
+				"thumbnail": {
+					"frames": {
+						"count": 0
+					},
+					"height": 270,
+					"path": "thumbnailer/thumb.jpg",
+					"type": "image",
+					"width": 270
+				}
+			},
+			"highlight": [
+				{
+					"field": "m2ts.format.filename",
+					"fragments": [
+						"\u0026#x2F;tmp\u0026#x2F;harvester485253057\u0026#x2F;ab210168127f3ac1ef68394106fdf093.\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "m2ts.format.format_long_name",
+					"fragments": [
+						"piped \u003cem\u003epng\u003c/em\u003e sequence"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_long_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e (Portable Network Graphics) image"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_name",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codecs_image",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.complete_name",
+					"fragments": [
+						"\u0026#x2F;tmp\u0026#x2F;harvester485253057\u0026#x2F;ab210168127f3ac1ef68394106fdf093.\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.file_extension",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_with_hint_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mime_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "stow_url",
+					"fragments": [
+						"file:\u0026#x2F;\u0026#x2F;\u0026#x2F;data\u0026#x2F;small\u0026#x2F;dup-kopia%203\u0026#x2F;Pasted%20image%20at%202017_03_01%2007_11%20AM.\u003cem\u003epng\u003c/em\u003e"
+					]
+				}
+			],
+			"score": 0.89747846
+		},
+		{
+			"result": {
+				"_id": "b981a591c1692066ed0a03b4803c11fc",
+				"file_size": 517310,
+				"last_modified": "2017-03-01T15:13:03Z",
+				"location_id": "AVqtzIBxSHvY6IzeCzPZ",
+				"location_kind": "local",
+				"location_name": "duplicatesss",
+				"mime_type": "image/png",
+				"name": "Pasted image at 2017_03_01 07_11 AM.png",
+				"stow_container_id": "/data/small",
+				"stow_container_name": "small",
+				"stow_url": "file:///data/small/dup-kopia/Pasted%20image%20at%202017_03_01%2007_11%20AM.png",
+				"thumbnail": {
+					"frames": {
+						"count": 0
+					},
+					"height": 270,
+					"path": "thumbnailer/thumb.jpg",
+					"type": "image",
+					"width": 270
+				}
+			},
+			"highlight": [
+				{
+					"field": "m2ts.format.format_long_name",
+					"fragments": [
+						"piped \u003cem\u003epng\u003c/em\u003e sequence"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_long_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e (Portable Network Graphics) image"
+					]
+				},
+				{
+					"field": "m2ts.streams.codec_name",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codec_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.codecs_image",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.file_extension",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.format_extensions_usually_used",
+					"fragments": [
+						"\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.image_format_with_hint_list",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.general.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.codec",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.commercial_name",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.format",
+					"fragments": [
+						"\u003cem\u003ePNG\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mediainfo.image.internet_media_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "mime_type",
+					"fragments": [
+						"image\u0026#x2F;\u003cem\u003epng\u003c/em\u003e"
+					]
+				},
+				{
+					"field": "stow_url",
+					"fragments": [
+						"file:\u0026#x2F;\u0026#x2F;\u0026#x2F;data\u0026#x2F;small\u0026#x2F;dup-kopia\u0026#x2F;Pasted%20image%20at%202017_03_01%2007_11%20AM.\u003cem\u003epng\u003c/em\u003e"
+					]
+				}
+			],
+			"score": 0.8638843
+		}
+	],
+	"aggregations": {
+		"terms": {
+			"adult_content.image_content": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"adult_content.racy_images": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"adult_content.racy_videos": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"adult_content.video_content": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"audio.bit_rate": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"audio.channels": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"audio.codec": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"audio.sampling_rate": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"celebrities_and_faces.gender": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"celebrities_and_faces.known_people": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"description.captions": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"description.tags": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"file.extension": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"file.permissions": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"file.type": {
+				"buckets": [
+					{
+						"key": "image",
+						"count": 5
+					}
+				],
+				"othersCount": 0
+			},
+			"general.codec": {
+				"buckets": [
+					{
+						"key": "PNG",
+						"count": 5
+					}
+				],
+				"othersCount": 0
+			},
+			"image.codec": {
+				"buckets": [
+					{
+						"key": "PNG",
+						"count": 5
+					}
+				],
+				"othersCount": 0
+			},
+			"image.color_space": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"image.compression_mode": {
+				"buckets": [
+					{
+						"key": "lossless",
+						"count": 5
+					}
+				],
+				"othersCount": 0
+			},
+			"image.format": {
+				"buckets": [
+					{
+						"key": "png",
+						"count": 5
+					}
+				],
+				"othersCount": 0
+			},
+			"location.city": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"location.country": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"location.places": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"location.region": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"photography.aperture": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"photography.flash_on": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"photography.focal_length": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"photography.iso_speed_ratings": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"photography.lens_make": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"photography.lens_model": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"storage.container": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"storage.location": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"storage.location_kind": {
+				"buckets": [
+					{
+						"key": "local",
+						"count": 5
+					}
+				],
+				"othersCount": 0
+			},
+			"video.codec": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"video.frame_rate": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"vision.description": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"vision.description_tags": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"vision.labels": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"vision.landmarks": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"vision.logos": {
+				"buckets": [],
+				"othersCount": 0
+			},
+			"weather.description": {
+				"buckets": [],
+				"othersCount": 0
+			}
+		},
+		"date_ranges": {},
+		"metrics": {
+			"max(audio.dbfs)": 0,
+			"max(audio.duration)": 0,
+			"max(audio.max_volume)": 0,
+			"max(audio.mean_volume)": 0,
+			"max(audio.true_peak_dbfs)": 0,
+			"max(file.size)": 517310,
+			"max(general.height_(px))": 471,
+			"max(general.width_(px))": 800,
+			"max(image.bit_depth)": 32,
+			"max(image.height_(px))": 471,
+			"max(image.width_(px))": 800,
+			"max(video.duration)": 0,
+			"max(weather.temperature_(° f))": 0,
+			"min(audio.dbfs)": 0,
+			"min(audio.duration)": 0,
+			"min(audio.max_volume)": 0,
+			"min(audio.mean_volume)": 0,
+			"min(audio.true_peak_dbfs)": 0,
+			"min(file.size)": 517310,
+			"min(general.height_(px))": 471,
+			"min(general.width_(px))": 800,
+			"min(image.bit_depth)": 32,
+			"min(image.height_(px))": 471,
+			"min(image.width_(px))": 800,
+			"min(video.duration)": 0,
+			"min(weather.temperature_(° f))": 0
+		},
+		"histograms": {}
+	}
+}
+`)

--- a/http/middleware/request_id.go
+++ b/http/middleware/request_id.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/graymeta/gmkit/uuid"
+)
+
+// RequestHeader is the header that marks the http request id set by the server.
+const RequestHeader = "X-Http-Request-Id"
+
+type reqID int
+
+const reqKey reqID = iota
+
+// RequestID sets the request id in the context to a uuid that can be traced
+// throughout the servers req/resp lifecycle.
+func RequestID(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		id, _ := uuid.TimestampUUID()
+		ctx := context.WithValue(r.Context(), reqKey, id)
+		w.Header().Set(RequestHeader, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+	return http.HandlerFunc(fn)
+}
+
+// GetReqID returns any request id that had been set in the context.
+func GetReqID(ctx context.Context) string {
+	s, _ := ctx.Value(reqKey).(string)
+	return s
+}


### PR DESCRIPTION
https://graymeta.atlassian.net/browse/GP-1769

Started pulling over the backoff code, which required pulling over some of the errors code, which in turn required pulling over some of the http middlewares code.