### PR TITLE
http: basic auth transport

### DIFF
--- a/http/basic_auth_transport.go
+++ b/http/basic_auth_transport.go
@@ -1,0 +1,25 @@
+package http
+
+import "net/http"
+
+// BasicAuthTransport is an http.RoundTripper that adds basic auth credentials to each request.
+type BasicAuthTransport struct {
+	username  string
+	password  string
+	transport http.RoundTripper
+}
+
+// NewBasicAuthTransport sets up a transport that wraps the provided transport.
+func NewBasicAuthTransport(t http.RoundTripper, username, password string) *BasicAuthTransport {
+	return &BasicAuthTransport{
+		username:  username,
+		password:  password,
+		transport: t,
+	}
+}
+
+// RoundTrip adds the basic auth creds to the request and passes it along to the wrapped transport.
+func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(t.username, t.password)
+	return t.transport.RoundTrip(req)
+}

--- a/http/basic_auth_transport_test.go
+++ b/http/basic_auth_transport_test.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicAuthTransport(t *testing.T) {
+	client := &http.Client{
+		Transport: NewBasicAuthTransport(http.DefaultTransport, "someuser", "somepassword"),
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		require.True(t, ok)
+		require.Equal(t, "someuser", user)
+		require.Equal(t, "somepassword", pass)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	_, err := client.Get(ts.URL)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds an http transport that wraps another transport and sets basic auth credentials on all requests.