### PR TITLE
GP-1770: api.Responder

### DIFF
--- a/api/decode.go
+++ b/api/decode.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Decode decodes the body of a request into the specified object.
+// If the object implements the OK interface, that method is called
+// to validate the object.
+func Decode(r *http.Request, v interface{}) error {
+	err := json.NewDecoder(r.Body).Decode(v)
+	if err != nil {
+		return &ErrJSON{err}
+	}
+	if obj, ok := v.(OK); ok {
+		if err := obj.OK(); err != nil {
+			return &ErrValidationFailed{err}
+		}
+	}
+	return nil
+}
+
+// OK checks to see if an object is valid or not.
+type OK interface {
+	OK() error
+}
+
+// ErrValidationFailed is returned by Decode if the object is not
+// valid.
+type ErrValidationFailed struct {
+	err error
+}
+
+// Error reports the error string.
+func (e *ErrValidationFailed) Error() string {
+	return fmt.Sprintf("validation of decoded object failed: %v", e.err)
+}
+
+// StatusCode returns the http status code that would refer to a validation error.
+func (e *ErrValidationFailed) StatusCode() int {
+	return http.StatusUnprocessableEntity
+}
+
+// ErrJSON error is returned by Decode when the incoming JSON
+// unmarshaling fails.
+type ErrJSON struct {
+	err error
+}
+
+// Error returns the error that unmarshal failed.
+func (e *ErrJSON) Error() string {
+	return fmt.Sprintf("failed to unmarshal JSON: %v", e.err)
+}
+
+// StatusCode returns the http status code that would refer to json payload that fails to decode error.
+func (e *ErrJSON) StatusCode() int {
+	return http.StatusBadRequest
+}

--- a/api/decode_test.go
+++ b/api/decode_test.go
@@ -1,0 +1,42 @@
+package api_test
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/graymeta/gmkit/api"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	body := strings.NewReader(`{
+		"name":"Piotr",
+		"number": 123456
+	}`)
+	r, err := http.NewRequest(http.MethodPost, "/something", body)
+	require.NoError(t, err)
+	var obj struct {
+		Name   string
+		Number int
+	}
+	require.NoError(t, api.Decode(r, &obj))
+	require.Equal(t, "Piotr", obj.Name)
+	require.Equal(t, 123456, obj.Number)
+}
+
+type notvalid struct{}
+
+func (notvalid) OK() error {
+	return errors.New("not ok")
+}
+
+func TestOK(t *testing.T) {
+	var obj notvalid
+	r, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(`{"something":true}`))
+	require.NoError(t, err)
+	err = api.Decode(r, &obj)
+	require.Equal(t, "validation of decoded object failed: not ok", err.Error())
+}

--- a/api/doc.go
+++ b/api/doc.go
@@ -1,0 +1,2 @@
+// Package api provides standard API request/response handling.
+package api

--- a/api/respond.go
+++ b/api/respond.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	gmerrors "github.com/graymeta/gmkit/errors"
+	"github.com/graymeta/gmkit/http/middleware"
+	"github.com/graymeta/gmkit/logger"
+
+	"github.com/pkg/errors"
+)
+
+// Responder writes API responses.
+// nil Responder is safe to use.
+type Responder struct {
+	log     *logger.L
+	version string
+}
+
+// NewResponder makes a new Responder object.
+func NewResponder(logger *logger.L, version string) *Responder {
+	return &Responder{log: logger, version: version}
+}
+
+// Option functions provide a means for manipulating things like adding additional
+// headers to responses.
+type Option func(w http.ResponseWriter)
+
+// Deprecated adds a header to indicate the particular endpoint is deprecated.
+func Deprecated(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Warning", `299 - "Deprecated"`)
+		next.ServeHTTP(w, req)
+	}
+	return http.HandlerFunc(fn)
+}
+
+// Header adds a Header to the response.
+func Header(key, value string) Option {
+	return func(w http.ResponseWriter) {
+		w.Header().Set(key, value)
+	}
+}
+
+// HeaderAPIVersion is the canonical name of the HTTP header key that reports the API version.
+const HeaderAPIVersion = `X-Api-Version`
+
+// With responds with the specified data.
+func (r *Responder) With(w http.ResponseWriter, req *http.Request, status int, data interface{}, opts ...Option) {
+	var buf bytes.Buffer
+	// cannot write to buf if data is nil, in case of StatusNoContent, this write will fail
+	// so we need an escape hatch here.
+	if data != nil {
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "\t")
+		err := enc.Encode(data)
+		if err != nil {
+			err = errors.Wrap(err, "failed to encode response object")
+			r.Err(w, req, err)
+			return
+		}
+	}
+	r.log.Debug("api_response",
+		"status", status,
+		"body", buf.String(),
+	)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set(HeaderAPIVersion, r.version)
+	for _, fn := range opts {
+		fn(w)
+	}
+	w.WriteHeader(status)
+	if _, err := io.Copy(w, &buf); err != nil {
+		err = errors.Wrap(err, "failed to copy response bytes")
+		r.log.Err("api_response", err)
+	}
+}
+
+// ErrorResponse is the body of an Error served up by Err
+type ErrorResponse struct {
+	Error struct {
+		Message   string `json:"message"`
+		RequestID string `json:"request_id,omitempty"`
+	} `json:"error"`
+}
+
+func newErr(requestID, msg string) ErrorResponse {
+	return ErrorResponse{
+		Error: struct {
+			Message   string `json:"message"`
+			RequestID string `json:"request_id,omitempty"`
+		}{
+			Message:   msg,
+			RequestID: requestID,
+		},
+	}
+}
+
+// Err responds with an error that corresponds to the behavior the type is illustrating.
+func (r *Responder) Err(w http.ResponseWriter, req *http.Request, err error) {
+	reqID := middleware.GetReqID(req.Context())
+	logMsg := true
+	defer func() {
+		sanitizedQuery := middleware.SanitizeQuery(req.URL.Query())
+		if logMsg {
+			msg := err.Error()
+			if ieErr, ok := err.(gmerrors.InternalErrorMessage); ok {
+				msg = ieErr.InternalErrorMessage()
+			}
+			r.log.Err("api_response_error",
+				"method", req.Method,
+				"path", req.URL.Path,
+				"query", sanitizedQuery.Encode(),
+				"err", msg,
+				"http_request_id", reqID,
+			)
+		}
+	}()
+
+	// not using a type switch here as we may have types that satisfy the behavior but
+	// are purposely not a valid error type as they return false, which indicates this.
+	// most useful when receiving a PGErr type that does fulfill more than 1 behavior potentially.
+	if httpErr, ok := err.(gmerrors.HTTP); ok {
+		r.With(w, req, httpErr.StatusCode(), newErr(reqID, err.Error()))
+		return
+	}
+
+	if nfErr, ok := err.(gmerrors.NotFounder); ok && nfErr.NotFound() {
+		logMsg = false
+		r.With(w, req, http.StatusNotFound, newErr(reqID, "resource not found"))
+		return
+	}
+
+	if exErr, ok := err.(gmerrors.Exister); ok && exErr.Exists() {
+		r.With(w, req, http.StatusUnprocessableEntity, newErr(reqID, "resource exists"))
+		return
+	}
+
+	if cfErr, ok := err.(gmerrors.Conflicter); ok && cfErr.Conflict() {
+		r.With(w, req, http.StatusUnprocessableEntity, newErr(reqID, "resource conflict"))
+		return
+	}
+
+	if tmpErr, ok := err.(gmerrors.Temporarier); ok && tmpErr.Temporary() {
+		r.With(w, req, http.StatusServiceUnavailable, newErr(reqID, "service unavailable"))
+		return
+	}
+
+	r.With(w, req, http.StatusInternalServerError, newErr(reqID, "internal server error"))
+}
+
+// OK responds with status code OK and JSON response indicating the operation succeeded
+func (r *Responder) OK(w http.ResponseWriter, req *http.Request, opts ...Option) {
+	r.With(w, req, http.StatusOK, struct {
+		OK bool `json:"ok"`
+	}{
+		OK: true,
+	}, opts...)
+}

--- a/api/respond_test.go
+++ b/api/respond_test.go
@@ -1,0 +1,98 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/graymeta/gmkit/api"
+	"github.com/graymeta/gmkit/logger"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWith(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+
+	type responseObj struct {
+		Name   string `json:"name"`
+		Number int    `json:"number"`
+	}
+
+	data := responseObj{
+		Name:   "Piotr",
+		Number: 123456,
+	}
+	status := http.StatusCreated
+
+	respond := api.NewResponder(logger.Default(), "v2")
+	respond.With(w, r, status, data)
+
+	require.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	require.Equal(t, "v2", w.Header().Get(api.HeaderAPIVersion))
+	require.Equal(t, http.StatusCreated, w.Code)
+	var decoded responseObj
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&decoded))
+	require.Equal(t, "Piotr", decoded.Name)
+	require.Equal(t, 123456, decoded.Number)
+}
+
+func TestEncodingErr(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+
+	obj := make(chan int)
+
+	status := http.StatusCreated
+
+	respond := api.NewResponder(logger.Default(), "v2")
+	respond.With(w, r, status, obj)
+
+	require.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	require.Equal(t, "v2", w.Header().Get(api.HeaderAPIVersion))
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	var decoded api.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&decoded))
+	require.Equal(t, "internal server error", decoded.Error.Message)
+}
+
+func TestRespondOK(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+
+	respond := api.NewResponder(logger.Default(), "v2")
+
+	respond.OK(w, r)
+
+	require.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	require.Equal(t, "v2", w.Header().Get(api.HeaderAPIVersion))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	type responseObj struct {
+		OK bool
+	}
+	var decoded responseObj
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&decoded))
+	require.True(t, decoded.OK)
+}
+
+func TestDeprecatedMiddleware(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/foo", nil)
+	handler.ServeHTTP(w, req)
+
+	require.Empty(t, w.Header().Get("Warning"))
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/foo", nil)
+	api.Deprecated(handler).ServeHTTP(w, req)
+
+	require.Equal(t, `299 - "Deprecated"`, w.Header().Get("Warning"))
+}

--- a/http/middleware/logging.go
+++ b/http/middleware/logging.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"net/url"
+)
+
+var paramsToSanitize = []string{"access_token", "code"}
+
+// SanitizeQuery used to sanitize the query params of any secrets so they do not show up in logs.
+func SanitizeQuery(vals url.Values) url.Values {
+	for _, v := range paramsToSanitize {
+		if vals.Get(v) != "" {
+			vals.Set(v, "REDACTED")
+		}
+	}
+	return vals
+}

--- a/http/middleware/logging_test.go
+++ b/http/middleware/logging_test.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeQuery(t *testing.T) {
+	v := make(url.Values)
+
+	v.Set("foo", "bar")
+	v.Set("access_token", "some token")
+
+	v = SanitizeQuery(v)
+
+	require.Equal(t, "bar", v.Get("foo"))
+	require.Equal(t, "REDACTED", v.Get("access_token"))
+}


### PR DESCRIPTION
https://graymeta.atlassian.net/browse/GP-1770

Pulls over the api.Responder from mf2. Drops the Err method, renames ErrV2 to Err.