### PR TITLE
GP-1397: ability to retry execution/response errors

### DIFF
--- a/http/httpc/retry_test.go
+++ b/http/httpc/retry_test.go
@@ -1,0 +1,54 @@
+package httpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/graymeta/gmkit/http/httpc/httpcfakes"
+
+	"github.com/graymeta/gmkit/backoff"
+	"github.com/graymeta/gmkit/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryResponseErrors(t *testing.T) {
+	_, addr := testhelpers.NewRandomPort(t)
+
+	t.Run("without RetryResponseErrors", func(t *testing.T) {
+		doer := new(httpcfakes.FakeDoer)
+		doer.DoReturns(nil, errors.New("some error"))
+
+		client := New(
+			doer,
+			WithBackoff(backoff.New(backoff.MaxCalls(2))),
+			WithBaseURL(addr),
+		)
+
+		err := client.
+			GET("/foo").
+			Do(context.TODO())
+
+		require.Error(t, err)
+		require.Equal(t, 1, doer.DoCallCount())
+	})
+
+	t.Run("with RetryResponseErrors", func(t *testing.T) {
+		doer := new(httpcfakes.FakeDoer)
+		doer.DoReturns(nil, errors.New("some error"))
+
+		client := New(
+			doer,
+			WithBackoff(backoff.New(backoff.MaxCalls(2))),
+			WithBaseURL(addr),
+		)
+
+		err := client.
+			GET("/foo").
+			RetryResponseErrors().
+			Do(context.TODO())
+
+		require.Error(t, err)
+		require.Equal(t, 2, doer.DoCallCount())
+	})
+}


### PR DESCRIPTION
https://graymeta.atlassian.net/browse/GP-1397

Right now if the httpc client hits a response error of some sort (DNS doesn't resolve, can't make a connection, etc.) the client won't retry the request.

This finishes the wiring to make it easy to retry errors of this sort.