### PR TITLE
bulk read request, error categories and classification

### DIFF
--- a/bulk/read.go
+++ b/bulk/read.go
@@ -1,0 +1,83 @@
+package bulk
+
+import (
+	"errors"
+	"net/http"
+
+	gmerrors "github.com/graymeta/gmkit/errors"
+)
+
+// ReadRequest is a request to read multiple IDs of a single resource type.
+type ReadRequest struct {
+	IDs []string `json:"ids"`
+}
+
+var errIDsNotSpecified = errors.New("one or more ids must be specified")
+var errBlankIDs = errors.New("blank id(s) specified")
+
+// OK validates the request.
+func (r ReadRequest) OK() error {
+	if len(r.IDs) == 0 {
+		return errIDsNotSpecified
+	}
+
+	for _, v := range r.IDs {
+		if v == "" {
+			return errBlankIDs
+		}
+	}
+
+	return nil
+}
+
+// ClassifyError takes an error and tries to bucket it into one of the error categories.
+func ClassifyError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if nf, ok := err.(gmerrors.NotFounder); ok && nf.NotFound() {
+		return ErrorNotFound
+	}
+
+	if hErr, ok := err.(gmerrors.HTTP); ok {
+		switch hErr.StatusCode() {
+		case http.StatusNotFound:
+			return ErrorNotFound
+		case http.StatusForbidden:
+			return ErrorForbidden
+		default:
+			return ErrorInternalServerError
+		}
+	}
+
+	return ErrorInternalServerError
+}
+
+// ResponseError captures information about an error for a specific resource.
+type ResponseError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+// NewResponseError initializes a NewResponseError
+func NewResponseError(err error) *ResponseError {
+	if err == nil {
+		return nil
+	}
+
+	return &ResponseError{
+		Message: err.Error(),
+		Type:    ClassifyError(err),
+	}
+}
+
+// Error categories.
+const (
+	// ErrorNotFound indicates the given resource was not found.
+	ErrorNotFound = "NotFound"
+	//ErrorForbidden indicates the given resource was not accessible by the user making the request.
+	ErrorForbidden = "Forbidden"
+	// ErrorInternalServerError indicates a server side error occured.
+	ErrorInternalServerError = "InternalServerError"
+)

--- a/bulk/read_test.go
+++ b/bulk/read_test.go
@@ -1,0 +1,96 @@
+package bulk
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadRequest(t *testing.T) {
+	tests := []struct {
+		description string
+		ids         []string
+		expected    error
+	}{
+		{"normal", []string{"abc123", "cde1234"}, nil},
+		{"nil ids", nil, errIDsNotSpecified},
+		{"blank ids", []string{"abc123", ""}, errBlankIDs},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			require.Equal(t, tt.expected, ReadRequest{IDs: tt.ids}.OK())
+		})
+	}
+}
+
+func TestResponseError(t *testing.T) {
+	tests := []struct {
+		description string
+		err         error
+		expected    *ResponseError
+	}{
+		{"nil error", nil, nil},
+		{"not found", notFound{true}, &ResponseError{Message: "not found", Type: ErrorNotFound}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			res := NewResponseError(tt.err)
+			if tt.expected == nil {
+				require.Nil(t, res)
+				return
+			}
+
+			require.Equal(t, tt.expected.Message, res.Message)
+			require.Equal(t, tt.expected.Type, res.Type)
+		})
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		description string
+		err         error
+		expected    string
+	}{
+		{"nil error", nil, ""},
+		{"not found interface and not found", notFound{true}, ErrorNotFound},
+		{"not found interface and found", notFound{false}, ErrorInternalServerError},
+		{"http error - 404", httpErr{http.StatusNotFound}, ErrorNotFound},
+		{"http error - 403", httpErr{http.StatusForbidden}, ErrorForbidden},
+		{"http error - 500", httpErr{http.StatusInternalServerError}, ErrorInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			require.Equal(t, tt.expected, ClassifyError(tt.err))
+		})
+	}
+}
+
+type notFound struct {
+	notFound bool
+}
+
+func (e notFound) Error() string {
+	return "not found"
+}
+
+func (e notFound) NotFound() bool {
+	return e.notFound
+}
+
+type httpErr struct {
+	code int
+}
+
+func (e httpErr) Error() string {
+	return fmt.Sprintf("%d", e.code)
+}
+
+func (e httpErr) StatusCode() int {
+	return e.code
+}


### PR DESCRIPTION
Implements the request format and error classification defined in https://github.com/graymeta/mf2/wiki/API-Bulk-Reads

Wonder if I should change `NotAccessible` to `Forbidden`?